### PR TITLE
Add Plotly route visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Beatiful Strava Route
 
-This Python application utilizes the Strava gpx route data visualizes it using OSMnx.
+This Python application utilizes the Strava GPX route data and visualizes it using OSMnx. An additional Plotly implementation is also provided for interactive maps.
 
 ## Overview
 
@@ -12,6 +12,7 @@ This application serves the purpose of plotting GPX routes recorded on Strava on
 - **GPX Parsing:** Parses GPX files fetched from Strava to extract route information.
 - **OSMnx Visualization:** Utilizes OSMnx library to plot routes onto OpenStreetMap.
 - **Interactive Interface:** Offers a user-friendly interface for selecting and displaying routes.
+- **Plotly Visualization:** `plotly_route.py` allows generating interactive maps using Plotly.
 
 ## Installation
 
@@ -31,9 +32,17 @@ This application serves the purpose of plotting GPX routes recorded on Strava on
 
 1. Run the application:
 
-    ```bash
+```bash
     streamlit run home.py
-    ```
+```
+
+### Plotly example
+
+To generate an interactive map of a GPX file using Plotly run:
+
+```bash
+python plotly_route.py <route.gpx>
+```
 
 ## Contributions
 

--- a/plotly_route.py
+++ b/plotly_route.py
@@ -1,0 +1,15 @@
+import sys
+import util as ut
+import plotly.io as pio
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python plotly_route.py <route.gpx>")
+        sys.exit(1)
+
+    gpx_path = sys.argv[1]
+    with open(gpx_path, "r") as f:
+        route_df = ut.read_gpx_file(f)
+
+    fig = ut.plot_route_plotly(route_df, title="Strava Route")
+    fig.show()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ gpxpy
 polyline
 shapely
 pandas
+plotly

--- a/util.py
+++ b/util.py
@@ -4,6 +4,7 @@ import gpxpy
 import gpxpy.gpx
 import polyline
 from shapely.geometry import Polygon, Point
+import plotly.graph_objects as go
 
 def read_gpx_file(gpx_file):
     """
@@ -216,8 +217,53 @@ def plot_figure(global_variable , route_df ,colorBackground , colorLines,colorRo
                color     = colorRoute , 
                linewidth = 4.0)
       #bbox={'facecolor': '#415DC0', 'edgecolor': '#415DC0', 'pad': 5}
-    ax.text(0.5, 0.03, title, ha='center', 
+    ax.text(0.5, 0.03, title, ha='center',
             va='center', transform=ax.transAxes, fontsize=40 ,color = colorText,
             bbox=dict(facecolor=colorBackground , edgecolor = colorBackground, alpha=0.5))
+
+    return fig
+
+
+def plot_route_plotly(route_df, title="Strava Route", route_color="#E64E25"):
+    """Create a Plotly map of a Strava route.
+
+    Parameters
+    ----------
+    route_df : pandas.DataFrame
+        DataFrame with `latitude` and `longitude` columns.
+    title : str, optional
+        Title for the figure.
+    route_color : str, optional
+        Color of the route line.
+
+    Returns
+    -------
+    plotly.graph_objects.Figure
+        The generated Plotly figure.
+    """
+
+    center = {
+        "lat": route_df.latitude.mean(),
+        "lon": route_df.longitude.mean(),
+    }
+
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scattermapbox(
+            lon=route_df["longitude"],
+            lat=route_df["latitude"],
+            mode="lines",
+            line=dict(color=route_color, width=3),
+            name=title,
+        )
+    )
+
+    fig.update_layout(
+        mapbox_style="open-street-map",
+        mapbox_center=center,
+        mapbox_zoom=12,
+        title=title,
+        margin={"r": 0, "t": 40, "l": 0, "b": 0},
+    )
 
     return fig


### PR DESCRIPTION
## Summary
- add optional Plotly support for displaying routes
- document Plotly usage in README
- include plotly requirement
- provide a simple script to draw GPX routes with Plotly

## Testing
- `python -m py_compile home.py util.py plotly_route.py`

------
https://chatgpt.com/codex/tasks/task_e_683f45eb26588321a52b3f67922c7506